### PR TITLE
Add alt tag to hero image for accessibility

### DIFF
--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -21,4 +21,4 @@ block content
 					a.block.text-pink-800.py-2.border.border-transparent.px-4(href="/login" class="hover:border-pink-800 hover:no-underline") Log in >
 
 		#right-side.flex-1
-			img(src="/img/laptop.jpg")
+			img(src="/img/laptop.jpg", alt="A woman in casual clothes using a laptop outside")


### PR DESCRIPTION
This commit adds an alt tag to the hero image in the index.pug view file, providing a text description of the image for users who are visually impaired or have images turned off in their browser. The alt tag value was set to 'A woman in casual clothes using a laptop outside', accurately describing the content and purpose of the image. This change helps improve accessibility and ensures that all users, regardless of ability, can understand and interact with our website's content.