### PR TITLE
Add progress meter

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -1876,6 +1876,88 @@ dd ol {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+
+/* Progress Meter styles */
+.meter {
+  box-sizing: content-box;
+  height: 2rem;
+  position: relative;
+  margin: 2rem 0;
+  background: linear-gradient(#901782, #ff1d69);
+  border-radius: 25px;
+  padding: 10px;
+  box-shadow: inset 0 -1px 1px rgba(255, 255, 255, 0.3);
+}
+.meter > span {
+  display: block;
+  height: 100%;
+  color: #fff;
+  font-size: 1.1rem;
+  font-weight: bold;
+  text-align: right;
+  padding: 0 1rem;
+  border-radius: 20px 8px 8px 20px;
+  background: linear-gradient(75deg, #f94355 1%, #fe951a 70%);
+  box-shadow: inset 0 2px 9px rgba(255, 255, 255, 0.3),
+  inset 0 -2px 6px rgba(0, 0, 0, 0.4);
+  position: relative;
+  overflow: hidden;
+}
+.meter > span:after,
+.animate > span > span {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background-image: linear-gradient(
+          -45deg,
+          rgba(255, 255, 255, 0.2) 25%,
+          transparent 25%,
+          transparent 50%,
+          rgba(255, 255, 255, 0.2) 50%,
+          rgba(255, 255, 255, 0.2) 75%,
+          transparent 75%,
+          transparent
+  );
+  z-index: 1;
+  background-size: 50px 50px;
+  animation: move 2s linear infinite;
+  border-radius: 20px 8px 8px 20px;
+  overflow: hidden;
+}
+
+.animate > span:after {
+  display: none;
+}
+
+@keyframes move {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 50px 50px;
+  }
+}
+
+.orange > span {
+  background-image: linear-gradient(#f1a165, #f36d0a);
+}
+
+.red > span {
+  background-image: linear-gradient(#f0a3a3, #f42323);
+}
+
+.green {
+  background-image: linear-gradient(#9ec400, #38761d);
+}
+
+.nostripes > span > span,
+.nostripes > span::after {
+  background-image: none;
+}
+
 @media (min-width: 640px) {
   .xs\:w-1\/3 {
     width: 33.333333%;

--- a/src/assets/js/progressBar.js
+++ b/src/assets/js/progressBar.js
@@ -1,0 +1,30 @@
+const meter = document.querySelector('.meter > span');
+const checkboxes = document.querySelectorAll('.watched');
+let completed = 0
+
+for (const checkbox of checkboxes) {
+    checkbox.addEventListener('change', updateProgress);
+    if (checkbox.checked) {
+        completed += 1;
+    }
+}
+
+function updateWidth() {
+    meter.style.width = `${completed / checkboxes.length * 100}%`;
+    meter.innerText = `${completed} / ${checkboxes.length}  `;
+    if (completed === checkboxes.length) {
+        meter.innerText = "You are a software engineer.";
+    }
+}
+
+function updateProgress(e) {
+    if (e.target.checked) {
+        completed += 1;
+    } else {
+        completed -= 1;
+    }
+    updateWidth()
+}
+
+// Set the progress bar width on page load
+updateWidth()

--- a/src/controllers/homework.js
+++ b/src/controllers/homework.js
@@ -113,7 +113,7 @@ export const showHomework =  async (req, res) => {
 };
 
 export const importData = async (req, res) => { 
-	if (!req.isAuthenticated()) return notLoggedIn(req, res);;
+	if (!req.isAuthenticated()) return notLoggedIn(req, res);
 	try {
 		const data = JSON.parse(JSON.parse(req.body.import).CBState);
 		const submitData = [];

--- a/src/controllers/homework.js
+++ b/src/controllers/homework.js
@@ -40,7 +40,7 @@ export const addEditHomework = async (req, res) => {
 				class: hwClass[i],
 				due: req.body.due,
 				description: hwDesc[i],
-				required: hwRequired[i] === "true" ? true : false,
+				required: hwRequired[i] === "true",
 			};
 			const hwItem = await HomeworkItem.findByIdAndUpdate(hwId[i] || mongoose.Types.ObjectId(), item, {upsert: true, new: true});
 			items.push(hwItem._id);

--- a/src/views/allLessons.pug
+++ b/src/views/allLessons.pug
@@ -1,5 +1,6 @@
 extends layouts/default.pug
 include ./mixins/lessonCard.pug
+include ./mixins/progressBar.pug
 
 block variables
 	- title = "Classes"
@@ -11,6 +12,7 @@ block content
 
 	h1.mb-4 All Classes
 
+	+progressBar
 	#lessons.grid.gap-y-12.gap-x-16(class="sm:gap-y-24 grid-cols-[repeat(auto-fill,_minmax(285px,_1fr))]")
 		each lesson in lessons
 			+lessonCard(lesson)
@@ -21,3 +23,4 @@ append scripts
 	if loggedIn
 		script(src="/js/lessonProgress.js")
 		script(src="/js/lessonDone.js")
+		script(src="/js/progressBar.js")

--- a/src/views/mixins/progressBar.pug
+++ b/src/views/mixins/progressBar.pug
@@ -1,0 +1,3 @@
+mixin progressBar
+    .meter.animate
+        span current


### PR DESCRIPTION
I've added a very basic progress meter to the All Classes page. At the moment, it's purely client-side with basic styling (to match Leon's stream background animation).
![image](https://user-images.githubusercontent.com/50963144/219514789-e46a0576-8f16-44a1-95cc-9d606f8a682f.png)



It works by counting the amount of lessons marked as completed on the page, as well as updating when a checkbox is ticked or unticked.

Since this is only client-side logic for now, we can't add this progress bar to the Dashboard view yet. However, this should be easily doable server-side if a query was retrieved for the amount of Lessons marked completed, served as the initial progress bar width value, and then the client-side js could keep the bar's visuals in sync between refreshes (if the user clicks some more boxes after).

Let me know what you think, and if any changes need to be made!

Some TODOs are to make for a smooth animation for the bar to fill up on page load, and to smoothly adjust as checkboxes are clicked.

_(Also, if you later end up rebuilding this app in React, I can rebuild the progress bar in React as well where all of this is quite a bit simpler)_