### PR TITLE
Fix broken slides' link in class 68

### DIFF
--- a/data/lessons.json
+++ b/data/lessons.json
@@ -1672,7 +1672,7 @@
 		"motivationTitle": "",
 		"note": "Due to technical difficulties, the last part of the class is available in a separate VOD <a href=\"https://www.twitch.tv/videos/1642824267\" target=\"_blank\">here</a>.",
 		"permalink": "how-to-get-a-job",
-		"slides": ["https://slides.com/leonnoel/100devs2-how-to-get-a-jobtw"],
+		"slides": ["https://slides.com/leonnoel/100devs2-how-to-get-a-job"],
 		"thumbnail": "/img/thumbnails/twitch.png",
 		"timestamps": [],
 		"title": "How to Get a Job",


### PR DESCRIPTION
The initial link, https://slides.com/leonnoel/100devs2-how-to-get-a-jobtw, was broken. I've replaced it with the correct link, https://slides.com/leonnoel/100devs2-how-to-get-a-job. I've learned a lot from this community and I hope I can give anything back to them.