### PR TITLE
Added conditionals to swap video and add a disclaimer on first lesson

### DIFF
--- a/src/views/lesson.pug
+++ b/src/views/lesson.pug
@@ -31,7 +31,8 @@ block content
 				if !lesson.videoId
 					img(src="/img/thumbnails/no-stream-lg.png")
 			if lesson.videoId === "o3IIobN4xR0"
-				p.flash.flash-error IMPORTANT NOTICE: The original first video of this cohort is temporarily unavailable. We've provided a video from the previous cohort as a temporary workaround. It is not the same, but contains enough info to get you to the second class.
+				p.flash.flash-error IMPORTANT NOTICE: The original first video of this cohort is temporarily unavailable. We've provided a video from the previous cohort as a temporary workaround. It is not the same, but contains enough info to get you to the second class. To understand more about why this is happening, 
+					a(href="https://twitter.com/leonnoel/status/1738502002978759059") please see this Twitter post from Leon.
 			.flex
 				.flex-1
 					if prev

--- a/src/views/lesson.pug
+++ b/src/views/lesson.pug
@@ -30,6 +30,8 @@ block content
 			#player
 				if !lesson.videoId
 					img(src="/img/thumbnails/no-stream-lg.png")
+			if lesson.videoId === "o3IIobN4xR0"
+				p.flash.flash-error IMPORTANT NOTICE: The original first video of this cohort is temporarily unavailable. We've provided a video from the previous cohort as a temporary workaround. It is not the same, but contains enough info to get you to the second class.
 			.flex
 				.flex-1
 					if prev
@@ -97,7 +99,7 @@ append scripts
 			var player;
 			function onYouTubeIframeAPIReady() {
 				player = new YT.Player('player', {
-					videoId: '#{lesson.videoId}',
+					videoId: '#{lesson.videoId}' === 'o3IIobN4xR0' ? 'YRemMgGfbKg' : '#{lesson.videoId}',
 				});
 			}
 			//- function setCurrentTime(slideNum) {


### PR DESCRIPTION
## Description

I've implemented conditional statements to check for the missing video ID. When a match is found, the video is swapped, and a brief disclaimer is added. 

This method, while differing from the initial suggestion in #31, I believe, minimizes user confusion by keeping them on the same page, rather than redirecting them to a new page or YouTube. 

This approach is not only straightforward to reverse or modify in the future but also was more manageable to implement without needing extensive knowledge of pug.js.

Please let me know if this solution is acceptable, or if I should instead proceed with adding a separate route and page as initially proposed.

Closes #31 

![image](https://github.com/labrocadabro/communitytaught/assets/18331781/85e0a93a-d269-4bfa-8e39-8338c78c7b6a)