### PR TITLE
Feat/timestamp link

### DIFF
--- a/src/assets/js/copyLink.js
+++ b/src/assets/js/copyLink.js
@@ -1,0 +1,28 @@
+const copyBtn = document.getElementById("copyLink");
+
+copyBtn.addEventListener("click", async () => {
+    try{
+
+        const timestamp = Math.floor(player.playerInfo.currentTime) || 0;
+        const url = window.location.href;
+        let link = url;
+        if (!url.includes("?")) {
+            link += `?t=${timestamp}`;
+        } else if (url.includes("t=")) {
+            link = url.replace(/t=\d+/, `t=${timestamp}`);
+        } else {
+            // this is for the case where there are other query strings
+            link += `&t=${timestamp}`;
+        }
+        await navigator.clipboard.writeText(link);
+        copyBtn.innerHTML = "Copied!";
+
+        // reset button text after 3 seconds
+        setTimeout(() => {
+            copyBtn.innerHTML = "Copy link at current time";
+        }, 2000);
+    }catch(err){
+        console.error('Failed to copy: ', err);
+    }
+ 
+});

--- a/src/controllers/lessons.js
+++ b/src/controllers/lessons.js
@@ -122,6 +122,7 @@ export const getLessonProgress = async (userId, lesson) => {
 
 export const showLesson = async (req, res) => {
 	try {
+		const timeStart = req.query.t || 0;
 		let lesson = await Lesson.findOne({
 			permalink: req.params.permalink,
 		}).lean();
@@ -148,7 +149,7 @@ export const showLesson = async (req, res) => {
 				assigned = await getHwProgress(req.user.id, assigned);
 			if (due.length) due = await getHwProgress(req.user.id, due);
 		}
-		res.render("lesson", { lesson, next, prev, assigned, due });
+		res.render("lesson", { lesson, next, prev, assigned, due, timeStart });
 	} catch (err) {
 		console.log(err);
 		res.redirect("/class/all");

--- a/src/views/lesson.pug
+++ b/src/views/lesson.pug
@@ -106,12 +106,12 @@ append scripts
 				player = new YT.Player('player', {
 					videoId: '#{lesson.videoId}' === 'o3IIobN4xR0' ? 'YRemMgGfbKg' : '#{lesson.videoId}',
 					playerVars: {
+						// this unfortunately doesn't work if the user is logged in and has 'youtube history' turned on
 						start: timeStart
 					},
+
 				});
 			}
-			
-		
 			//- function setCurrentTime(slideNum) {
 			//- 	var object = [ 0, 320 ];
 			//- 	player.seekTo(object[slideNum]);

--- a/src/views/lesson.pug
+++ b/src/views/lesson.pug
@@ -8,6 +8,7 @@ block variables
 	- active = "Classes"
 	- const watched = lesson.watched ? "checked" : ""
 	- const formattedDates = lesson.dates.map(date => date.toLocaleDateString('en-US', {day: "numeric", month: "short", year: "numeric"})).join(' / ')
+	//- - const timeStart = lesson && lesson.timeStart ? lesson.timeStart : 0
 
 block content
 	if !loggedIn
@@ -84,24 +85,33 @@ block content
 			.mb-6(class="shadow-[0_2px_10px_0_rgba(0,0,0,0.1)]")
 				+homework(homework)
 
+	if timeStart
+		p#timeStart.hidden #{timeStart || 0}
+
 append scripts
 	if loggedIn
 		script(src="/js/hwDone.js")
 		script(src="/js/hwProgress.js")
 		script(src="/js/lessonProgress.js")
-
 	if lesson.videoId && !lesson.twitchVideo
+		
 		script.
 			var tag = document.createElement('script');
 			tag.src = "https://www.youtube.com/iframe_api";
 			var firstScriptTag = document.getElementsByTagName('script')[0];
 			firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 			var player;
+			const timeStart = document.getElementById('timeStart')?.innerText || 0;
 			function onYouTubeIframeAPIReady() {
 				player = new YT.Player('player', {
 					videoId: '#{lesson.videoId}' === 'o3IIobN4xR0' ? 'YRemMgGfbKg' : '#{lesson.videoId}',
+					playerVars: {
+						start: timeStart
+					},
 				});
 			}
+			
+		
 			//- function setCurrentTime(slideNum) {
 			//- 	var object = [ 0, 320 ];
 			//- 	player.seekTo(object[slideNum]);

--- a/src/views/lesson.pug
+++ b/src/views/lesson.pug
@@ -8,7 +8,6 @@ block variables
 	- active = "Classes"
 	- const watched = lesson.watched ? "checked" : ""
 	- const formattedDates = lesson.dates.map(date => date.toLocaleDateString('en-US', {day: "numeric", month: "short", year: "numeric"})).join(' / ')
-	//- - const timeStart = lesson && lesson.timeStart ? lesson.timeStart : 0
 
 block content
 	if !loggedIn
@@ -45,6 +44,9 @@ block content
 					if next
 						h3
 							a(href="/class/" + next) Next Class
+			button#copyLink.hidden.p-2.border.bg-pink-800.text-white.text-xs.font-medium.mt-4.rounded-md Copy link at current time
+						
+
 		#info
 			if loggedIn
 				if lesson.videoId
@@ -89,6 +91,7 @@ block content
 		p#timeStart.hidden #{timeStart || 0}
 
 append scripts
+	script(src="/js/copyLink.js")
 	if loggedIn
 		script(src="/js/hwDone.js")
 		script(src="/js/hwProgress.js")
@@ -107,15 +110,21 @@ append scripts
 					videoId: '#{lesson.videoId}' === 'o3IIobN4xR0' ? 'YRemMgGfbKg' : '#{lesson.videoId}',
 					playerVars: {
 						// this unfortunately doesn't work if the user is logged in and has 'youtube history' turned on
+						// see https://stackoverflow.com/questions/77691282/youtube-iframe-api-start-time-not-working-when-youtube-history-is-enabled for possible workaround (not implemented yet)
 						start: timeStart
-					},
 
+					},
+					events: {
+						'onReady': onPlayerReady,
+					}
 				});
+
+
 			}
-			//- function setCurrentTime(slideNum) {
-			//- 	var object = [ 0, 320 ];
-			//- 	player.seekTo(object[slideNum]);
-			//- }
+			function onPlayerReady(event) {
+				// this will lazy load the button
+				document.getElementById('copyLink').classList.remove('hidden');
+			}
 
 	else if lesson.twitchVideo
 		script(src="https://player.twitch.tv/js/embed/v1.js")


### PR DESCRIPTION
closes https://github.com/labrocadabro/communitytaught/issues/58

- Added support to start the video if a query `t=seconds` is in the link. Example:`url&t=50` 
- Added button on class page to copy link at current timestamp to the clipboard




### screenshots

<img width="569" alt="image" src="https://github.com/labrocadabro/communitytaught/assets/45009203/c8501d7a-eeab-44ac-9157-b581dde38338">


Button to copy link
<img width="365" alt="image" src="https://github.com/labrocadabro/communitytaught/assets/45009203/76127d3a-d294-4857-93e9-c087268854cb">

Animation when button is clicked 
<img width="166" alt="image" src="https://github.com/labrocadabro/communitytaught/assets/45009203/30d0fac3-28ce-4923-93ea-d67ab9538c10">

