### PR TITLE
feat/video chapters

### DIFF
--- a/src/assets/js/copyLink.js
+++ b/src/assets/js/copyLink.js
@@ -1,0 +1,57 @@
+// const copyBtn = document.getElementById("copyLink");
+const copyLinkTimestampBtn = document.querySelectorAll(".copyLinkTimestamp");
+
+async function copyLink(time) {
+  try {
+    const timestamp = Math.floor(time) || 0;
+    const url = window.location.href;
+    let link = url;
+    if (!url.includes("?")) {
+      link += `?t=${timestamp}`;
+    } else if (url.includes("t=")) {
+      link = url.replace(/t=\d+/, `t=${timestamp}`);
+    } else {
+      // this is for the case where there are other query strings
+      link += `&t=${timestamp}`;
+    }
+    await navigator.clipboard.writeText(link);
+  } catch (err) {
+    console.error("Failed to copy: ", err);
+  }
+}
+
+// copyBtn.addEventListener("click", async () => {
+//   try {
+//     await copyLink(player.playerInfo.currentTime || 0);
+//     copyBtn.innerHTML = "Copied!";
+
+//     // reset button text after 3 seconds
+//     setTimeout(() => {
+//       copyBtn.innerHTML = "Copy link at current time";
+//     }, 2000);
+//   } catch (err) {
+//     console.error("Failed to copy: ", err);
+//   }
+// });
+
+copyLinkTimestampBtn.forEach((btn) => {
+  // add icon to button
+  btn.innerHTML = `<i class="fas fa-link"></i>`;
+
+  btn.addEventListener("click", async () => {
+    try {
+      const timestamp = btn.dataset.time;
+      await copyLink(timestamp);
+
+      // change the icon to a checkmark
+      btn.innerHTML = `<i class="fas fa-check"></i>`;
+
+      // reset button text after 3 seconds
+      setTimeout(() => {
+        btn.innerHTML = `<i class="fas fa-link"></i>`;
+      }, 1000);
+    } catch (err) {
+      console.error("Failed to copy: ", err);
+    }
+  });
+});

--- a/src/assets/js/goToTime.js
+++ b/src/assets/js/goToTime.js
@@ -1,0 +1,31 @@
+const goToTimeBtns = document.querySelectorAll(".goToTime");
+
+function formatTimestamp(timeRemaining) {
+  // convert seconds to hh:mm:ss
+  const hours = Math.floor(timeRemaining / (60 * 60));
+  const minutes = Math.floor((timeRemaining % (60 * 60)) / 60);
+  const seconds = Math.floor(timeRemaining % 60);
+  const padZeros = (num) => num.toString().padStart(2, "0");
+
+  // Sheds "HH:" when duration is under 1 hour (3600 seconds)
+  if (timeRemaining >= 3600) {
+    return `${padZeros(hours)}:${padZeros(minutes)}:${padZeros(seconds)}`;
+  }
+  return `${padZeros(minutes)}:${padZeros(seconds)}`;
+}
+
+goToTimeBtns.forEach((btn) => {
+  // add space after so that it looks even like 3:00__ vs 30:00_ vs 3:00:00
+  btn.innerHTML = `${formatTimestamp(btn.dataset.time)} - ${btn.dataset.title}`;
+  btn.addEventListener("click", () => {
+    if (!player) return;
+
+    if (
+      btn.dataset.time &&
+      typeof Number(btn.dataset.time) === "number" &&
+      Number(btn.dataset.time) > 0
+    ) {
+      player.seekTo(btn.dataset.time);
+    }
+  });
+});

--- a/src/controllers/lessons.js
+++ b/src/controllers/lessons.js
@@ -34,11 +34,28 @@ export const addEditLesson = async (req, res) => {
 		}
 		let slides = [];
 		const timestamps = [];
-		for (let i = 0; i < req.body.tsTime.length; i++) {
-			timestamps.push({
-				time: Number(req.body.tsTime[i]),
-				title: req.body.tsTitle[i],
-			});
+		const tsTime = req.body.tsTime 
+		const tsTitle = req.body.tsTitle 
+
+		if (tsTime && tsTitle) {
+			// if there are multiple timestamps, tsTime and tsTitle will be arrays
+			if (Array.isArray(tsTime)) {
+				for (let i = 0; i < tsTime.length; i++) {
+					if (tsTime[i] && tsTitle[i]) {
+						timestamps.push({
+							time: tsTime[i],
+							title: tsTitle[i],
+						});
+					}
+				}
+			}
+			// if there is only one timestamp, tsTime and tsTitle will be strings, and not arrays
+			else {
+				timestamps.push({
+					time: tsTime,
+					title: tsTitle,
+				});
+			}
 		}
 		const lessonData = {
 			videoId: req.body.videoId,
@@ -141,6 +158,9 @@ export const showLesson = async (req, res) => {
 			.lean()
 			.sort({ _id: 1 })
 			.populate(["items", "extras"]);
+		console.log("before",lesson.timestamps);
+		lesson.timestamps = lesson.timestamps.sort((a, b) => a.time - b.time);
+		console.log("after",lesson.timestamps);
 
 		if (req.isAuthenticated()) {
 			lesson = await getLessonProgress(req.user.id, lesson);

--- a/src/controllers/lessons.js
+++ b/src/controllers/lessons.js
@@ -158,9 +158,8 @@ export const showLesson = async (req, res) => {
 			.lean()
 			.sort({ _id: 1 })
 			.populate(["items", "extras"]);
-		console.log("before",lesson.timestamps);
+	
 		lesson.timestamps = lesson.timestamps.sort((a, b) => a.time - b.time);
-		console.log("after",lesson.timestamps);
 
 		if (req.isAuthenticated()) {
 			lesson = await getLessonProgress(req.user.id, lesson);

--- a/src/views/lesson.pug
+++ b/src/views/lesson.pug
@@ -71,6 +71,23 @@ block content
 	if lesson.videoId && !lesson.twitchVideo
 		h3.mt-8 Feed the algorithm and spread the word!
 		p #[a(href=`https://www.youtube.com/watch?v=${lesson.videoId}` target="_blank") Like, comment and subscribe on Youtube]
+	
+	if lesson.timestamps && lesson.timestamps.length
+	.flex.justify-start.items-start.flex-col.mr-8
+		h3.mt-10.mb-3.w-96 Timestamps
+		ul.max-h-60.overflow-y-auto.w-96.border-2.border-pink-800.rounded-lg.p-4
+			each timestamp, index in lesson.timestamps
+				li.border-b-2.border-pink-800.p-2.flex.flex-row.items-center
+					button(
+						class="goToTime text-left w-full text-pink-800 hover:text-pink-600"
+						data-time=timestamp.time
+						data-title=timestamp.title
+					) 
+					i.copyLinkTimestamp(id=`ts-title-${index}` data-time=timestamp.time)
+					
+					
+
+
 
 	if assigned.length
 		h2.mt-10.mb-3 Homework Assigned
@@ -85,6 +102,8 @@ block content
 				+homework(homework)
 
 append scripts
+	script(src="/js/copyLink.js")
+	script(src="/js/goToTime.js")
 	if loggedIn
 		script(src="/js/hwDone.js")
 		script(src="/js/hwProgress.js")

--- a/src/views/lesson.pug
+++ b/src/views/lesson.pug
@@ -73,17 +73,17 @@ block content
 		p #[a(href=`https://www.youtube.com/watch?v=${lesson.videoId}` target="_blank") Like, comment and subscribe on Youtube]
 	
 	if lesson.timestamps && lesson.timestamps.length
-	.flex.justify-start.items-start.flex-col.mr-8
-		h3.mt-10.mb-3.w-96 Timestamps
-		ul.max-h-60.overflow-y-auto.w-96.border-2.border-pink-800.rounded-lg.p-4
-			each timestamp, index in lesson.timestamps
-				li.border-b-2.border-pink-800.p-2.flex.flex-row.items-center
-					button(
-						class="goToTime text-left w-full text-pink-800 hover:text-pink-600"
-						data-time=timestamp.time
-						data-title=timestamp.title
-					) 
-					i.copyLinkTimestamp(id=`ts-title-${index}` data-time=timestamp.time)
+		.flex.justify-start.items-start.flex-col.mr-8
+			h3.mt-10.mb-3.w-96 Timestamps
+			ul.max-h-60.overflow-y-auto.w-96.border-2.border-pink-800.rounded-lg.p-4
+				each timestamp, index in lesson.timestamps
+					li.border-b-2.border-pink-800.p-2.flex.flex-row.items-center
+						button(
+							class="goToTime text-left w-full text-pink-800 hover:text-pink-600"
+							data-time=timestamp.time
+							data-title=timestamp.title
+						) 
+						i.copyLinkTimestamp(id=`ts-title-${index}` data-time=timestamp.time)
 					
 					
 


### PR DESCRIPTION
closes https://github.com/labrocadabro/communitytaught/issues/61

Add support for chapters/timestamps

- Reused the existing (unused) timestamps in the dbmodel/edit class page
- fixed bug with the existing timestamp input in the edit class page where, when a single timestamp was newly added, it formatted it incorrectly on the db
- added a chapters component on the class page
- in the chapters component, added support for clicking on a specific chapter to go to that specific time in the video (with no page refresh)
- in the chapters component, added support for feedback when user clicks the copy button to copy a chapter (copies the link)


### screenshots
Edit class page
<img width="785" alt="image" src="https://github.com/labrocadabro/communitytaught/assets/45009203/347ac957-e2d9-461c-88b5-14771fae763f">

Lesson page
<img width="556" alt="image" src="https://github.com/labrocadabro/communitytaught/assets/45009203/fb7b9a93-ca83-4340-9df7-4f4d0bc83d01">
